### PR TITLE
Fixed issue #2

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ exports = module.exports = {
      * @returns {string|*}
      */
     camelCase: function camelCase(str) {
-        return str.replace(/([a-z])_(\w)/g, function (g) {
+        return str.replace(/([a-zA-Z0-9])_(\w)/g, function (g) {
             return g[0] + g[2].toUpperCase();
         });
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "camelscore",
   "description": "camelCase and under_score utilities for objects.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "Trevor Livingston <tlivings@gmail.com>",
   "repository": {
     "type": "git",

--- a/test/test-camelscore.js
+++ b/test/test-camelscore.js
@@ -8,7 +8,7 @@ test('test', function (t) {
     t.test('camelCase', function (assert) {
         var str = camelscore.camelCase('foo_bar');
 
-        assert.plan(4);
+        assert.plan(5);
 
         assert.strictEqual(str, 'fooBar', 'camel cased 1 underscore.');
 
@@ -23,6 +23,10 @@ test('test', function (t) {
         str = camelscore.camelCase('foo_bar_baz_');
 
         assert.strictEqual(str, 'fooBarBaz_', 'camel cased and left trailing _.');
+
+        str = camelscore.camelCase('is_2FA_login');
+
+        assert.strictEqual(str, 'is2FALogin', 'camel cased uppercase words with 2 underscores.');
     });
 
     t.test('underscore', function (assert) {


### PR DESCRIPTION
As per the issue, `is_2FA_login` when camelized becomes `is2FA_login` and not `is2FALogin`. This PR fixes that changing `[a-z]` to `[a-zA-Z0-9]`. I did not use `\w` coz it also includes underscores.
